### PR TITLE
Build with go version 1.26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,3 +8,5 @@ jobs:
     uses: gardenlinux/package-build/.github/workflows/build.yml@main
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
+      build_dep: |
+        gardenlinux/package-golang 1.26.2-1gl0


### PR DESCRIPTION
**What this PR does / why we need it**:
Build with go version `1.26.2`.