### PR TITLE
Revert "Update golang dependency to 1.26.2"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,5 +8,3 @@ jobs:
     uses: gardenlinux/package-build/.github/workflows/build.yml@main
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
-      build_dep: |
-        gardenlinux/package-golang 1.26.2-1gl0

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module gardenlinux-update
 
-go 1.26.2
+go 1.23.2
 
 require oras.land/oras-go/v2 v2.5.0
 


### PR DESCRIPTION
Reverts gardenlinux/package-gardenlinux-update#19

Was merged to the main branch instead of rel-2150, so revert it to keep main using the latest build chain by default.